### PR TITLE
update espower-loader to 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-- '0.11'
+- 'iojs'
+- '0.12'
 - '0.10'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/azu/intelli-espower-loader/issues"
   },
   "peerDependencies": {
-    "espower-loader": "^0.10.0"
+    "espower-loader": "^0.11.0"
   },
   "devDependencies": {
     "mocha": "^2.0.1"


### PR DESCRIPTION
Hi, today I've released [Release v0.11.0: StackTrace adjustment (2015-05-06)](https://github.com/twada/espower-loader/releases/tag/v0.11.0).

- [x] update espower-loader to 0.11.0
- [x] add Node 0.12 build
- [x] add io.js build

Thanks!